### PR TITLE
Remove duplicate Maven package command in CI

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -37,4 +37,3 @@ jobs:
         # The key name here MUST match what's in application.properties
         jwt.secret: ${{ secrets.JWT_SECRET }}
       run: mvn -B package --file backend/pom.xml
-      run: mvn -B package --file backend/pom.xml


### PR DESCRIPTION
Eliminated a redundant 'mvn -B package' command from the CI pipeline configuration to streamline the build process.