### PR TITLE
Update .gitignore and add test application.properties

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -33,4 +33,4 @@ build/
 .vscode/
 
 # Ignore the local properties file containing secrets
-application.properties
+/src/main/resources/application.properties

--- a/backend/src/test/resources/application.properties
+++ b/backend/src/test/resources/application.properties
@@ -1,0 +1,13 @@
+# src/test/resources/application.properties
+
+# Use an in-memory H2 database for testing
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+
+# Tell JPA to create the schema for our entities
+spring.jpa.hibernate.ddl-auto=create-drop
+
+# Show the SQL queries that Hibernate generates
+spring.jpa.show-sql=true


### PR DESCRIPTION
Modified .gitignore to ignore only the main application.properties file and not the test configuration. Added a new application.properties for test resources to configure an in-memory H2 database and JPA settings for testing.